### PR TITLE
Fix Class path not found

### DIFF
--- a/Configuration/TypoScript/Plugin/setup.txt
+++ b/Configuration/TypoScript/Plugin/setup.txt
@@ -127,15 +127,13 @@ plugin.tx_t3sportstats {
     default.options.orderby.PLAYER.LAST_NAME = asc
     scorerlist =< lib.t3sports.statsPlayerFilter
     scorerlist {
-      filter = tx_t3sportstats_filter_PlayerStats
       options.orderby.CUSTOM = goals desc
     	options.having = sum(goals) > 0
       data =< lib.t3sports.statsData
     }
     assistlist =< lib.t3sports.statsPlayerFilter
     assistlist {
-    	filter = tx_t3sportstats_filter_PlayerStats
-    	options.orderby.CUSTOM = assists desc
+      options.orderby.CUSTOM = assists desc
     	options.having = sum(assists) > 0
       data =< lib.t3sports.statsData
     }


### PR DESCRIPTION
Error in scorerlist and assistlist filter view:

```
UNCAUGHT EXCEPTION FOR VIEW: tx_t3sportstats_actions_PlayerStats
CODE: 0
MESSAGE: Class path not found: /typo3conf/ext/t3sportstats/filter/PlayerStats/class.tx_t3sportstats_filter_PlayerStats.php
STACK:
Exception: Class path not found: /typo3conf/ext/t3sportstats/filter/PlayerStats/class.tx_t3sportstats_filter_PlayerStats.php in /typo3conf/ext/rn_base/class.tx_rnbase.php:301
```