### PR TITLE
Align `initFilter` method with rn-base v1.16.11

### DIFF
--- a/Classes/Filter/CoachStatsFilter.php
+++ b/Classes/Filter/CoachStatsFilter.php
@@ -3,6 +3,7 @@
 namespace System25\T3sports\Filter;
 
 use Sys25\RnBase\Frontend\Filter\BaseFilter;
+use Sys25\RnBase\Frontend\Request\RequestInterface;
 use Sys25\RnBase\Utility\Strings;
 use System25\T3sports\Search\StatsSearchBuilder;
 use System25\T3sports\Utility\ScopeController;
@@ -39,13 +40,13 @@ class CoachStatsFilter extends BaseFilter
     /**
      * Abgeleitete Filter können diese Methode überschreiben und zusätzliche Filter setzen.
      *
-     * @param array $fields
-     * @param array $options
-     * @param \tx_rnbase_IParameters $parameters
-     * @param \tx_rnbase_configurations $configurations
-     * @param string $confId
+     * @param array            $fields
+     * @param array            $options
+     * @param RequestInterface $request
+     *
+     * @return bool
      */
-    protected function initFilter(&$fields, &$options)
+    protected function initFilter(&$fields, &$options, RequestInterface $request)
     {
         $parameters = $this->getParameters();
         $configurations = $this->getConfigurations();

--- a/Classes/Filter/PlayerStatsFilter.php
+++ b/Classes/Filter/PlayerStatsFilter.php
@@ -3,6 +3,7 @@
 namespace System25\T3sports\Filter;
 
 use Sys25\RnBase\Frontend\Filter\BaseFilter;
+use Sys25\RnBase\Frontend\Request\RequestInterface;
 use Sys25\RnBase\Utility\Strings;
 use System25\T3sports\Search\StatsSearchBuilder;
 use System25\T3sports\Utility\ScopeController;
@@ -39,13 +40,13 @@ class PlayerStatsFilter extends BaseFilter
     /**
      * Abgeleitete Filter können diese Methode überschreiben und zusätzliche Filter setzen.
      *
-     * @param array $fields
-     * @param array $options
-     * @param \tx_rnbase_IParameters $parameters
-     * @param \tx_rnbase_configurations $configurations
-     * @param string $confId
+     * @param array            $fields
+     * @param array            $options
+     * @param RequestInterface $request
+     *
+     * @return bool
      */
-    protected function initFilter(&$fields, &$options)
+    protected function initFilter(&$fields, &$options, RequestInterface $request)
     {
         $parameters = $this->getParameters();
         $configurations = $this->getConfigurations();

--- a/Classes/Filter/RefereeStatsFilter.php
+++ b/Classes/Filter/RefereeStatsFilter.php
@@ -3,6 +3,7 @@
 namespace System25\T3sports\Filter;
 
 use Sys25\RnBase\Frontend\Filter\BaseFilter;
+use Sys25\RnBase\Frontend\Request\RequestInterface;
 use Sys25\RnBase\Utility\Strings;
 use System25\T3sports\Search\StatsSearchBuilder;
 use System25\T3sports\Utility\ScopeController;
@@ -39,13 +40,13 @@ class RefereeStatsFilter extends BaseFilter
     /**
      * Abgeleitete Filter können diese Methode überschreiben und zusätzliche Filter setzen.
      *
-     * @param array $fields
-     * @param array $options
-     * @param \tx_rnbase_IParameters $parameters
-     * @param \tx_rnbase_configurations $configurations
-     * @param string $confId
+     * @param array            $fields
+     * @param array            $options
+     * @param RequestInterface $request
+     *
+     * @return bool
      */
-    protected function initFilter(&$fields, &$options)
+    protected function initFilter(&$fields, &$options, RequestInterface $request)
     {
         $parameters = $this->getParameters();
         $configurations = $this->getConfigurations();

--- a/Classes/Utility/StatsConfig.php
+++ b/Classes/Utility/StatsConfig.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace System25\T3sports\Utility;
+
 use Sys25\RnBase\Utility\Strings;
 
 /***************************************************************


### PR DESCRIPTION
This patch fixes compatibility for `CoachStatsFilter`, `PlayerStatsFilter` und `RefereeStatsFilter` with `EXT:rn_base` version 1.16.11